### PR TITLE
[sdktechno-51] requirements files missing in python images

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,6 +123,7 @@ tasks.register("buildAllTechnologies") {
 tasks {
     "incrementBuildMeta"(SemverIncrementBuildMetaTask::class) {
         doFirst {
+            buildMeta = buildMeta.replace("/","-")
             if (buildMeta == "master") {
                 buildMeta = ""
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath("com.saagie:technologiesplugin:1.2.6")
+        classpath("com.saagie:technologiesplugin:1.2.8")
     }
 }
 apply<SaagieTechnologiesPackageGradlePlugin>()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath("com.saagie:technologiesplugin:1.2.8")
+        classpath("com.saagie:technologiesplugin:1.2.9")
     }
 }
 apply<SaagieTechnologiesPackageGradlePlugin>()
@@ -129,7 +129,6 @@ tasks {
             }
             this.project.version = version as String
         }
-
         doLast {
             with(File("version.properties")) {
                 val version = File("versions")

--- a/technologies/job/python/python-2.7/Dockerfile
+++ b/technologies/job/python/python-2.7/Dockerfile
@@ -20,9 +20,8 @@ RUN apt update -qq && apt install -yqq --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*;
 # LIBS PART END
 
-COPY resources/requirements.txt .
-RUN pip --no-cache-dir install -r requirements.txt \
-    && rm -rf requirements.txt \
+COPY resources/requirements.txt /tmp/requirements.txt
+RUN pip --no-cache-dir install -r /tmp/requirements.txt \
     && rm -rf /root/.cachex \
     && rm -rf /boot/.cache/pip \
     && rm -rf ~/.cache/pip

--- a/technologies/job/python/python-3.5/Dockerfile
+++ b/technologies/job/python/python-3.5/Dockerfile
@@ -19,9 +19,8 @@ RUN apt update -qq && apt install -qqy --no-install-recommends \
 
 # Need to read requirements.txt file sequentially to ensure consistent installatin order (Cython needed first)
 # (ConfigSace install required by auto-sklearn will fail without that before the other install)
-COPY resources/requirements.txt .
-RUN grep -v '^#' requirements.txt | xargs -n 1 -L 1 pip --no-cache-dir install \
-    && rm -rf requirements.txt \
+COPY resources/requirements.txt /tmp/requirements.txt
+RUN grep -v '^#' /tmp/requirements.txt | xargs -n 1 -L 1 pip --no-cache-dir install \
     && rm -rf /root/.cachex \
     && rm -rf /boot/.cache/pip \
     && rm -rf ~/.cache/pip

--- a/technologies/job/python/python-3.6/Dockerfile
+++ b/technologies/job/python/python-3.6/Dockerfile
@@ -48,9 +48,8 @@ RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu18
 
 # Need to read requirements.txt file sequentially to ensure consistent installatin order (Cython needed first)
 # (ConfigSace install required by auto-sklearn will fail without that before the other install)
-COPY resources/requirements.txt .
-RUN grep -v '^#' requirements.txt | xargs -n 1 -L 1 pip --no-cache-dir install \
-    && rm -rf requirements.txt \
+COPY resources/requirements.txt /tmp/requirements.txt
+RUN grep -v '^#' /tmp/requirements.txt | xargs -n 1 -L 1 pip --no-cache-dir install \
     && rm -rf /root/.cachex \
     && rm -rf /boot/.cache/pip \
     && rm -rf ~/.cache/pip

--- a/technologies/job/python/python-3.7/Dockerfile
+++ b/technologies/job/python/python-3.7/Dockerfile
@@ -48,9 +48,8 @@ RUN curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu18
 
 # Need to read requirements.txt file sequentially to ensure consistent installatin order (Cython needed first)
 # (ConfigSace install required by auto-sklearn will fail without that before the other install)
-COPY resources/requirements.txt .
-RUN grep -v '^#' requirements.txt | xargs -n 1 -L 1 pip --no-cache-dir install \
-    && rm -rf requirements.txt \
+COPY resources/requirements.txt /tmp/requirements.txt
+RUN grep -v '^#' /tmp/requirements.txt | xargs -n 1 -L 1 pip --no-cache-dir install \
     && rm -rf /root/.cachex \
     && rm -rf /boot/.cache/pip \
     && rm -rf ~/.cache/pip


### PR DESCRIPTION
Closes #111 
keep requirements.txt file in python images to allow indirectly inherited images to install those requirements.