### PR TITLE
[hotfix][appzeppelin] remove duplicated id /small refacto

### DIFF
--- a/technologies/app/jupyter/jupyter-base/context.yaml
+++ b/technologies/app/jupyter/jupyter-base/context.yaml
@@ -6,6 +6,6 @@ trustLevel: stable
 ports:
   - port: 8888
     name: Notebook
-    rewrite: false
+    rewriteUrl: false
     basePath: SAAGIE_BASE_PATH
 volumes: ["/notebooks-dir"]

--- a/technologies/app/jupyter/jupyter-base/dockerInfo.yaml
+++ b/technologies/app/jupyter/jupyter-base/dockerInfo.yaml
@@ -1,4 +1,4 @@
 image: saagie/jupyter-python-nbk
 baseTag: v2
-dynamicVersion: 1.54.0_appjupyter
-version: v2-1.54.0
+dynamicVersion: 1.61.0_zeppelin_version3
+version: v2-1.61.0_zeppelin_version3

--- a/technologies/app/jupyter/metadata.yaml
+++ b/technologies/app/jupyter/metadata.yaml
@@ -17,10 +17,10 @@ contexts:
     ports:
       - port: 8888
         name: Notebook
-        rewrite: false
+        rewriteUrl: false
         basePath: SAAGIE_BASE_PATH
     volumes: ["/notebooks-dir"]
     dockerInfo:
       image: saagie/jupyter-python-nbk
       baseTag: v2
-      version: v2-1.54.0
+      version: v2-1.61.0_zeppelin_version3

--- a/technologies/app/nifi/metadata.yaml
+++ b/technologies/app/nifi/metadata.yaml
@@ -18,7 +18,7 @@ contexts:
     ports:
       - port: 80
         name: Nifi
-        rewrite: false
+        rewriteUrl: false
         basePath: SAAGIE_BASE_PATH
     volumes: ["/opt/nifi/nifi-current/conf"]
     dockerInfo:

--- a/technologies/app/nifi/metadata.yaml
+++ b/technologies/app/nifi/metadata.yaml
@@ -11,7 +11,7 @@ customFlags: []
 
 contexts:
   - id: 1.9.2
-    label: Nifi 1.9.2
+    label: "[Lab] Nifi 1.9.2"
     releaseNotes: First iteration post migration for apache nifi 1.9.2
     available: true
     trustLevel: experimental
@@ -24,4 +24,4 @@ contexts:
     dockerInfo:
       image: saagie/nifi
       baseTag: 1.9.2
-      version: 1.9.2-1.54.0_appnifi
+      version: 1.9.2-1.61.0_zeppelin_version3

--- a/technologies/app/nifi/nifi-1.9.2/context.yaml
+++ b/technologies/app/nifi/nifi-1.9.2/context.yaml
@@ -1,5 +1,5 @@
 id: 1.9.2
-label: Nifi 1.9.2
+label: "[Lab] Nifi 1.9.2"
 releaseNotes: First iteration post migration for apache nifi 1.9.2
 available: true
 trustLevel: experimental

--- a/technologies/app/nifi/nifi-1.9.2/context.yaml
+++ b/technologies/app/nifi/nifi-1.9.2/context.yaml
@@ -6,6 +6,6 @@ trustLevel: experimental
 ports:
   - port: 80
     name: Nifi
-    rewrite: false
+    rewriteUrl: false
     basePath: SAAGIE_BASE_PATH
 volumes: ["/opt/nifi/nifi-current/conf"]

--- a/technologies/app/nifi/nifi-1.9.2/dockerInfo.yaml
+++ b/technologies/app/nifi/nifi-1.9.2/dockerInfo.yaml
@@ -1,4 +1,4 @@
 image: saagie/nifi
 baseTag: 1.9.2
-dynamicVersion: 1.54.0_appnifi
-version: 1.9.2-1.54.0_appnifi
+dynamicVersion: 1.61.0_zeppelin_version3
+version: 1.9.2-1.61.0_zeppelin_version3

--- a/technologies/app/zeppelin-0.7.3/metadata.yaml
+++ b/technologies/app/zeppelin-0.7.3/metadata.yaml
@@ -23,4 +23,4 @@ contexts:
     dockerInfo:
       image: saagie/zeppelin-nbk
       baseTag: 0.7.3
-      version: 0.7.3-1.60.0_zeppelin_version3
+      version: 0.7.3-1.61.0_zeppelin_version3

--- a/technologies/app/zeppelin-0.7.3/metadata.yaml
+++ b/technologies/app/zeppelin-0.7.3/metadata.yaml
@@ -1,7 +1,7 @@
 version: v1
 type: APP
-id: zeppelin
-label: Zeppelin Notebook
+id: zeppelin-0.7.3
+label: Zeppelin Notebook 0.7.3
 baseline: Data Science Notebook
 description: Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more.
 available: true
@@ -23,4 +23,4 @@ contexts:
     dockerInfo:
       image: saagie/zeppelin-nbk
       baseTag: 0.7.3
-      version: 0.7.3-1.59.0
+      version: 0.7.3-1.60.0_zeppelin_version3

--- a/technologies/app/zeppelin-0.7.3/technology.yaml
+++ b/technologies/app/zeppelin-0.7.3/technology.yaml
@@ -1,7 +1,7 @@
 version: v1
 type: APP
-id: zeppelin
-label: Zeppelin Notebook
+id: zeppelin-0.7.3
+label: Zeppelin Notebook 0.7.3
 baseline: Data Science Notebook
 description: Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more.
 available: true

--- a/technologies/app/zeppelin-0.7.3/zeppelin-0.7.3/Dockerfile
+++ b/technologies/app/zeppelin-0.7.3/zeppelin-0.7.3/Dockerfile
@@ -1,6 +1,6 @@
 FROM apache/zeppelin:0.7.3
 
-MAINTAINER Saagie
+LABEL maintainer=Saagie
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -31,9 +31,8 @@ RUN apt-get -qq update && apt-get -yqq install --no-install-recommends \
 ########################## LIBS PART END ##########################
 
 ########################## Install Spark 2.1.0 for Hadoop 2.6 BEGIN ##########################
-RUN cd /tmp && wget https://archive.apache.org/dist/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.6.tgz -O /tmp/spark-2.1.0-bin-hadoop2.6.tgz
-
-RUN cd /tmp && tar -xzf spark-2.1.0-bin-hadoop2.6.tgz && \
+RUN cd /tmp && wget https://archive.apache.org/dist/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.6.tgz -O /tmp/spark-2.1.0-bin-hadoop2.6.tgz && \
+  tar -xzf spark-2.1.0-bin-hadoop2.6.tgz && \
   cp spark-2.1.0-bin-hadoop2.6/conf/log4j.properties.template spark-2.1.0-bin-hadoop2.6/conf/log4j.properties && \
   mkdir -p /usr/local/spark/2.1.0 && mv spark-2.1.0-bin-hadoop2.6/* /usr/local/spark/2.1.0 && \
   rm -rf spark-2.1.0-bin-hadoop2.6.tgz spark-2.1.0-bin-hadoop2.6
@@ -42,12 +41,11 @@ RUN cd /tmp && tar -xzf spark-2.1.0-bin-hadoop2.6.tgz && \
 # Add a startup script that will setup Spark conf before running Zeppelin
 COPY resources/saagie-zeppelin.sh /zeppelin
 COPY resources/saagie-zeppelin-config.sh /zeppelin
-RUN chmod 744 /zeppelin/saagie-zeppelin.sh /zeppelin/saagie-zeppelin-config.sh
-
+RUN chmod 744 /zeppelin/saagie-zeppelin.sh /zeppelin/saagie-zeppelin-config.sh && \
 # Add CRON to copy interpreter.json to persisted folder
-RUN echo "* * * * * cp -f /zeppelin/conf/interpreter.json /notebook/" >> mycron && \
-crontab mycron && \
-rm mycron
+    echo "* * * * * cp -f /zeppelin/conf/interpreter.json /notebook/" >> mycron && \
+    crontab mycron && \
+    rm mycron
 
 # Keep default ENTRYPOINT as apache/zeppelin is using Tini, which is great.
 CMD ["/zeppelin/saagie-zeppelin.sh"]

--- a/technologies/app/zeppelin-0.7.3/zeppelin-0.7.3/dockerInfo.yaml
+++ b/technologies/app/zeppelin-0.7.3/zeppelin-0.7.3/dockerInfo.yaml
@@ -1,4 +1,4 @@
 image: saagie/zeppelin-nbk
 baseTag: 0.7.3
-dynamicVersion: 1.59.0_appzeppelin
-version: 0.7.3-1.59.0
+dynamicVersion: 1.60.0_zeppelin_version3
+version: 0.7.3-1.60.0_zeppelin_version3

--- a/technologies/app/zeppelin-0.7.3/zeppelin-0.7.3/dockerInfo.yaml
+++ b/technologies/app/zeppelin-0.7.3/zeppelin-0.7.3/dockerInfo.yaml
@@ -1,4 +1,4 @@
 image: saagie/zeppelin-nbk
 baseTag: 0.7.3
-dynamicVersion: 1.60.0_zeppelin_version3
-version: 0.7.3-1.60.0_zeppelin_version3
+dynamicVersion: 1.61.0_zeppelin_version3
+version: 0.7.3-1.61.0_zeppelin_version3

--- a/technologies/app/zeppelin-0.9.0/metadata.yaml
+++ b/technologies/app/zeppelin-0.9.0/metadata.yaml
@@ -1,7 +1,7 @@
 version: v1
 type: APP
-id: zeppelin
-label: Zeppelin Notebook
+id: zeppelin-0.9.0
+label: Zeppelin Notebook 0.9.0
 baseline: Data Science Notebook
 description: Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more.
 available: true
@@ -23,4 +23,4 @@ contexts:
     dockerInfo:
       image: saagie/zeppelin-nbk
       baseTag: 0.9.0
-      version: 0.9.0-1.59.0
+      version: 0.9.0-1.60.0_zeppelin_version3

--- a/technologies/app/zeppelin-0.9.0/metadata.yaml
+++ b/technologies/app/zeppelin-0.9.0/metadata.yaml
@@ -23,4 +23,4 @@ contexts:
     dockerInfo:
       image: saagie/zeppelin-nbk
       baseTag: 0.9.0
-      version: 0.9.0-1.60.0_zeppelin_version3
+      version: 0.9.0-1.61.0_zeppelin_version3

--- a/technologies/app/zeppelin-0.9.0/technology.yaml
+++ b/technologies/app/zeppelin-0.9.0/technology.yaml
@@ -1,7 +1,7 @@
 version: v1
 type: APP
-id: zeppelin
-label: Zeppelin Notebook
+id: zeppelin-0.9.0
+label: Zeppelin Notebook 0.9.0
 baseline: Data Science Notebook
 description: Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more.
 available: true

--- a/technologies/app/zeppelin-0.9.0/zeppelin-0.9.0/Dockerfile
+++ b/technologies/app/zeppelin-0.9.0/zeppelin-0.9.0/Dockerfile
@@ -52,14 +52,12 @@ RUN mkdir -p ${SPARK_BASE_DIR} \
 # Add a startup script that will setup Spark conf before running Zeppelin
 COPY resources/saagie-zeppelin.sh /zeppelin
 COPY resources/saagie-zeppelin-config.sh /zeppelin
-RUN chmod 744 /zeppelin/saagie-zeppelin.sh /zeppelin/saagie-zeppelin-config.sh
-
-RUN mkdir ${ZEPPELIN_NOTEBOOK_DIR}
-
+RUN chmod 744 /zeppelin/saagie-zeppelin.sh /zeppelin/saagie-zeppelin-config.sh && \
+    mkdir ${ZEPPELIN_NOTEBOOK_DIR} && \
 # Add CRON to copy interpreter.json to persisted folder
-RUN echo "* * * * * cp -f /zeppelin/conf/interpreter.json ${ZEPPELIN_NOTEBOOK_DIR}/" >> mycron && \
-crontab mycron && \
-rm mycron
+    echo "* * * * * cp -f /zeppelin/conf/interpreter.json ${ZEPPELIN_NOTEBOOK_DIR}/" >> mycron && \
+    crontab mycron && \
+    rm mycron
 
 # Keep default ENTRYPOINT as apache/zeppelin is using Tini, which is great.
 CMD ["/zeppelin/saagie-zeppelin.sh"]

--- a/technologies/app/zeppelin-0.9.0/zeppelin-0.9.0/dockerInfo.yaml
+++ b/technologies/app/zeppelin-0.9.0/zeppelin-0.9.0/dockerInfo.yaml
@@ -1,4 +1,4 @@
 image: saagie/zeppelin-nbk
 baseTag: 0.9.0
-dynamicVersion: 1.60.0_zeppelin_version3
-version: 0.9.0-1.60.0_zeppelin_version3
+dynamicVersion: 1.61.0_zeppelin_version3
+version: 0.9.0-1.61.0_zeppelin_version3

--- a/technologies/app/zeppelin-0.9.0/zeppelin-0.9.0/dockerInfo.yaml
+++ b/technologies/app/zeppelin-0.9.0/zeppelin-0.9.0/dockerInfo.yaml
@@ -1,4 +1,4 @@
 image: saagie/zeppelin-nbk
 baseTag: 0.9.0
-dynamicVersion: 1.59.0_appzeppelin
-version: 0.9.0-1.59.0
+dynamicVersion: 1.60.0_zeppelin_version3
+version: 0.9.0-1.60.0_zeppelin_version3

--- a/version.properties
+++ b/version.properties
@@ -1,6 +1,6 @@
-version.buildmeta=
+version.buildmeta=zeppelin_version3
 version.major=1
 version.minor=60
 version.patch=0
 version.prerelease=
-version.semver=1.60.0
+version.semver=1.60.0+zeppelin_version3


### PR DESCRIPTION
Also corrects [SDKTECHNO-76] - closes #181
and correct [SDKTECHNO-78] - closes #186 

Adds [LAB] Before experimental technologies and contexts : Nifi 
Change rewrite to rewriteUrl when necessary in context.yaml
Differentiiate Zeppelin technologies ids by adding -<version> to id 

+ some minor refacto : 
 - use LABEL instead of MAINTAINER
 - concatenate some RUN to minimize number of layers
 - use oneline wget + untar when possible 