### PR TITLE
Add link to docs.saagie.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 This repository contains all certified technologies used in Saagie.
 It also contains some experimental technologies before being certified.
 
+For information about using these technologies with your Saagie platform, refer to [Saagie's official documentation](https://docs.saagie.io/product/latest/sdk/index.html).
+
 ## CONTENTS
 
 This repository contains all job and application technologies.


### PR DESCRIPTION
I added the link for the main SDK page. Should we add links to the Technology Catalog pages, too? They'll be published soon.