### PR TITLE
Add ability to change default CRAN to custom value

### DIFF
--- a/technologies/job/r/r-3.4.4-base/entrypoint
+++ b/technologies/job/r/r-3.4.4-base/entrypoint
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Change default CRAN to ENV VAR if present
+if [[ -z "${R_CUSTOM_CRAN}" ]]; then
+    echo "No custom CRAN defined, using default, you can configure one using R_CUSTOM_CRAN env var"
+else
+    sed -i 's#https://cloud.r-project.org#'"${R_CUSTOM_CRAN}"'#g' /usr/lib/R/etc/Rprofile.site
+fi
+
 set -euo pipefail
 if compgen -G "*.zip*" > /dev/null; then
     echo "Zip file detected ... unzipping ..."

--- a/technologies/job/r/r-3.5.3-base/entrypoint
+++ b/technologies/job/r/r-3.5.3-base/entrypoint
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Change default CRAN to ENV VAR if present
+if [[ -z "${R_CUSTOM_CRAN}" ]]; then
+    echo "No custom CRAN defined, using default, you can configure one using R_CUSTOM_CRAN env var"
+else
+    sed -i 's#https://cloud.r-project.org#'"${R_CUSTOM_CRAN}"'#g' /usr/lib/R/etc/Rprofile.site
+fi
+
 set -euo pipefail
 if compgen -G "*.zip*" > /dev/null; then
     echo "Zip file detected ... unzipping ..."

--- a/technologies/job/r/r-3.6.2-base/entrypoint
+++ b/technologies/job/r/r-3.6.2-base/entrypoint
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Change default CRAN to ENV VAR if present
+if [[ -z "${R_CUSTOM_CRAN}" ]]; then
+    echo "No custom CRAN defined, using default, you can configure one using R_CUSTOM_CRAN env var"
+else
+    sed -i 's#https://cloud.r-project.org#'"${R_CUSTOM_CRAN}"'#g' /usr/lib/R/etc/Rprofile.site
+fi
+
 set -euo pipefail
 if compgen -G "*.zip*" > /dev/null; then
     echo "Zip file detected ... unzipping ..."

--- a/technologies/job/r/r-3.6.3-base/entrypoint
+++ b/technologies/job/r/r-3.6.3-base/entrypoint
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Change default CRAN to ENV VAR if present
+if [[ -z "${R_CUSTOM_CRAN}" ]]; then
+    echo "No custom CRAN defined, using default, you can configure one using R_CUSTOM_CRAN env var"
+else
+    sed -i 's#https://cloud.r-project.org#'"${R_CUSTOM_CRAN}"'#g' /usr/lib/R/etc/Rprofile.site
+fi
+
 set -euo pipefail
 if compgen -G "*.zip*" > /dev/null; then
     echo "Zip file detected ... unzipping ..."

--- a/technologies/job/r/r-4.0-base/entrypoint
+++ b/technologies/job/r/r-4.0-base/entrypoint
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Change default CRAN to ENV VAR if present
+if [[ -z "${R_CUSTOM_CRAN}" ]]; then
+    echo "No custom CRAN defined, using default, you can configure one using R_CUSTOM_CRAN env var"
+else
+    sed -i 's#https://cloud.r-project.org#'"${R_CUSTOM_CRAN}"'#g' /usr/lib/R/etc/Rprofile.site
+fi
+
 set -euo pipefail
 if compgen -G "*.zip*" > /dev/null; then
     echo "Zip file detected ... unzipping ..."


### PR DESCRIPTION
Sometimes it happens that you want your jobs to automatically be based on custom CRAN sites, wether you host your own private packages, or run saagie inside a secure environment with no access to external URLs.

This merge request allow to use a Saagie environment variable R_CUSTOM_CRAN to pass a specific URL to use by default.

Despite this change can be made manually inside an RScript, it remains usefull if the end users are agnostic about CRAN mechanisms.
