### PR TITLE
Add an exposed port to be able to create Dash app

### DIFF
--- a/technologies/app/dash/metadata.yaml
+++ b/technologies/app/dash/metadata.yaml
@@ -14,6 +14,11 @@ contexts:
     releaseNotes: First port of Dash into Saagie
     available: true
     trustLevel: experimental
+    ports:
+      - port: 8050
+        name: Dash
+        rewriteUrl: false
+        basePath: SAAGIE_BASE_PATH
     dockerInfo:
       image: saagie/dash
       baseTag: 2.0.0


### PR DESCRIPTION
Add an exposed port to be able to create Dash app in one click (avoid custom app configuration)